### PR TITLE
Improve memory objects

### DIFF
--- a/build/posix/memory_file_posix.c
+++ b/build/posix/memory_file_posix.c
@@ -10,6 +10,25 @@
 #include <string.h>
 #include <unistd.h>
 
+const mem_slot_t memory_slots[] = {
+    {
+        .id = OBJ_RUN,
+        .bootable = true,
+        .loaded = true
+    },
+    {
+        .id = OBJ_1,
+        .bootable = false,
+        .loaded = false
+    },
+    {
+        .id = OBJ_2,
+        .bootable = false,
+        .loaded = false
+    },
+    {OBJ_END}
+};
+
 char* memory_objects_mapper[] = {
     [OBJ_GOLD] = "antani",
     [OBJ_RUN] = "../assets/internal_flash_simulator",

--- a/build/posix/memory_file_posix.c
+++ b/build/posix/memory_file_posix.c
@@ -67,7 +67,7 @@ pull_error memory_open_impl(mem_object* ctx, obj_id obj, mem_mode_t mode) {
     return PULL_SUCCESS;
 }
 
-int memory_read_impl(mem_object* ctx, void* memory_buffer, uint16_t size, uint32_t offset) {
+int memory_read_impl(mem_object* ctx, void* memory_buffer, size_t size, address_t offset) {
     PULL_ASSERT(ctx != NULL);
     PULL_ASSERT(ctx->fp >= 0);
     if (ctx->start_offset+offset+size > ctx->end_offset) {
@@ -82,7 +82,7 @@ int memory_read_impl(mem_object* ctx, void* memory_buffer, uint16_t size, uint32
 
 }
 
-int memory_write_impl(mem_object* ctx, const void* memory_buffer, uint16_t size, uint32_t offset) {
+int memory_write_impl(mem_object* ctx, const void* memory_buffer, size_t size, address_t offset) {
     PULL_ASSERT(ctx != NULL);
     PULL_ASSERT(ctx->fp > 0);
     if (ctx->start_offset+offset+size > ctx->end_offset) {

--- a/build/posix/memory_file_posix.c
+++ b/build/posix/memory_file_posix.c
@@ -10,22 +10,6 @@
 #include <string.h>
 #include <unistd.h>
 
-const mem_slot_t memory_slots[] = {
-    {
-        .id = OBJ_RUN,
-        .bootable = true
-    },
-    {
-        .id = OBJ_1,
-        .bootable = false
-    },
-    {
-        .id = OBJ_2,
-        .bootable = false
-    },
-    {OBJ_END}
-};
-
 char* memory_objects_mapper[] = {
     [OBJ_GOLD] = "antani",
     [OBJ_RUN] = "../assets/internal_flash_simulator",

--- a/build/posix/memory_file_posix.c
+++ b/build/posix/memory_file_posix.c
@@ -10,7 +10,21 @@
 #include <string.h>
 #include <unistd.h>
 
-const int8_t memory_objects[] = { OBJ_1, OBJ_2, OBJ_END};
+const mem_slot_t memory_slots[] = {
+    {
+        .id = OBJ_RUN,
+        .bootable = true
+    },
+    {
+        .id = OBJ_1,
+        .bootable = false
+    },
+    {
+        .id = OBJ_2,
+        .bootable = false
+    },
+    {OBJ_END}
+};
 
 char* memory_objects_mapper[] = {
     [OBJ_GOLD] = "antani",
@@ -19,6 +33,7 @@ char* memory_objects_mapper[] = {
     [OBJ_2] = "../assets/external_flash_simulator",
     [TEST_MEMORY_FILE] = "../assets/test_memory",
 };
+
 int memory_objects_start[] = {
     [OBJ_GOLD] = 0,
     [OBJ_RUN] = 0x7000,
@@ -35,26 +50,26 @@ int memory_objects_end[] = {
 };
 
 /******* Testing Function ******/
-void override_memory_object(obj_id id, char* path, int start, int end) {
+void override_memory_object(mem_id_t id, char* path, int start, int end) {
     memory_objects_mapper[id] = path;
     memory_objects_start[id] = start;
     memory_objects_end[id] = end;
 }
 /**** End Testing Function *****/
 
-pull_error resource_mapper(mem_object* ctx, obj_id obj) {
-    if (obj <= OBJ_FIRST || obj >= OBJ_LAST) {
+pull_error resource_mapper(mem_object_t* ctx, mem_id_t id) {
+    if (id <= OBJ_FIRST || id >= OBJ_LAST) {
         return INVALID_OBJECT_ERROR;
     }
-    ctx->path = memory_objects_mapper[obj];
-    ctx->start_offset = memory_objects_start[obj];
-    ctx->end_offset = memory_objects_end[obj];
+    ctx->path = memory_objects_mapper[id];
+    ctx->start_offset = memory_objects_start[id];
+    ctx->end_offset = memory_objects_end[id];
     return PULL_SUCCESS;
 }
 
-pull_error memory_open_impl(mem_object* ctx, obj_id obj, mem_mode_t mode) {
-    bzero(ctx, sizeof(mem_object));
-    if (resource_mapper(ctx, obj) != PULL_SUCCESS) {
+pull_error memory_open_impl(mem_object_t* ctx, mem_id_t id, mem_mode_t mode) {
+    bzero(ctx, sizeof(mem_object_t));
+    if (resource_mapper(ctx, id) != PULL_SUCCESS) {
         log_error(MEMORY_MAPPING_ERROR, "Error mapping the resource\n");
         return MEMORY_MAPPING_ERROR;
     }
@@ -67,7 +82,7 @@ pull_error memory_open_impl(mem_object* ctx, obj_id obj, mem_mode_t mode) {
     return PULL_SUCCESS;
 }
 
-int memory_read_impl(mem_object* ctx, void* memory_buffer, size_t size, address_t offset) {
+int memory_read_impl(mem_object_t* ctx, void* memory_buffer, size_t size, address_t offset) {
     PULL_ASSERT(ctx != NULL);
     PULL_ASSERT(ctx->fp >= 0);
     if (ctx->start_offset+offset+size > ctx->end_offset) {
@@ -82,7 +97,7 @@ int memory_read_impl(mem_object* ctx, void* memory_buffer, size_t size, address_
 
 }
 
-int memory_write_impl(mem_object* ctx, const void* memory_buffer, size_t size, address_t offset) {
+int memory_write_impl(mem_object_t* ctx, const void* memory_buffer, size_t size, address_t offset) {
     PULL_ASSERT(ctx != NULL);
     PULL_ASSERT(ctx->fp > 0);
     if (ctx->start_offset+offset+size > ctx->end_offset) {
@@ -96,12 +111,12 @@ int memory_write_impl(mem_object* ctx, const void* memory_buffer, size_t size, a
     return write(ctx->fp, memory_buffer, size);
 }
 
-pull_error memory_flush_impl(mem_object* ctx) {
+pull_error memory_flush_impl(mem_object_t* ctx) {
     // not implemented since there is no buffer
     return PULL_SUCCESS;
 }
 
-pull_error memory_close_impl(mem_object* ctx) {
+pull_error memory_close_impl(mem_object_t* ctx) {
     if (ctx == NULL) {
         return MEMORY_CLOSE_ERROR;
     }

--- a/build/posix/memory_file_posix.h
+++ b/build/posix/memory_file_posix.h
@@ -26,14 +26,4 @@ enum memory_objects_enum {
 void override_memory_object(obj_id id, char* path, int start, int end);
 /***** End Testing functions *****/
 
-pull_error memory_open_impl(mem_object* ctx, obj_id obj, mem_mode_t mode);
-
-int memory_read_impl(mem_object* ctx, void* memory_buffer, uint16_t size, uint32_t offset);
-
-int memory_write_impl(mem_object* ctx, const void* memory_buffer, uint16_t size, uint32_t offset);
-
-pull_error memory_flush_impl(mem_object* ctx);
-
-pull_error memory_close_impl(mem_object* ctx);
-
 #endif // MEMORY_FILE_POSIX_H_

--- a/build/posix/memory_file_posix.h
+++ b/build/posix/memory_file_posix.h
@@ -1,10 +1,10 @@
 #ifndef MEMORY_FILE_POSIX_H_
 #define MEMORY_FILE_POSIX_H_
 
-#include "common/libpull.h"
-#include "memory/memory.h"
+#include <common/libpull.h>
+#include <memory/memory.h>
 
-struct mem_object_ {
+struct mem_object_t {
     char* path;
     int fp;
     int start_offset;
@@ -23,7 +23,7 @@ enum memory_objects_enum {
 };
 
 /******* Testing functions *******/
-void override_memory_object(obj_id id, char* path, int start, int end);
+void override_memory_object(mem_id_t id, char* path, int start, int end);
 /***** End Testing functions *****/
 
 #endif // MEMORY_FILE_POSIX_H_

--- a/include/agents/update.h
+++ b/include/agents/update.h
@@ -90,9 +90,9 @@ typedef struct update_agent_ctx_t {
     subscriber_ctx sctx;
     receiver_ctx rctx;
     txp_ctx rtxp;
-    obj_id id;
-    mem_object new_obj;
-    mem_object obj_t;
+    mem_id_t id;
+    mem_object_t new_obj;
+    mem_object_t obj_t;
     pull_error err;
 } update_agent_ctx_t;
 

--- a/include/common/external.h
+++ b/include/common/external.h
@@ -18,6 +18,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 extern const mem_slot_t memory_slots[];
+extern const version_t running_version;
 
 /** OBJ_END defines the final value used to stop the cicle on the
  * memory objects. */

--- a/include/common/external.h
+++ b/include/common/external.h
@@ -11,31 +11,19 @@
 #define EXTERNAL_H_
 
 #include <stdint.h>
+#include <memory/memory.h>
 
- #ifdef __cplusplus
- extern "C" {
- #endif /* __cplusplus */
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
-/** This array of integer identify the memory objects
- * with a valid manifest present in memory.
- * All the value of this array must be positive and
- * must match a valid memory object in the device memory.
- * The last element must be a negative value, or the
- * OBJ_END constant.
- *
- * Example: if you need to have two memory objects to store
- * the updates you can define the variable in this way:
- *
- *     const int8_t memory_objects[] = {OBJ_1, OBJ2, OBJ_END};
- *
- */
-extern const int8_t memory_objects[];
+extern const mem_slot_t memory_slots[];
 
 /** OBJ_END defines the final value used to stop the cicle on the
  * memory objects. */
 #define OBJ_END -1
 
 #ifdef __cplusplus
- }
+}
 #endif /* __cplusplus */
 #endif /* \} EXTERNAL_H_ */

--- a/include/common/libpull.h
+++ b/include/common/libpull.h
@@ -12,12 +12,12 @@
 #include <common/libpull_config.h>
 #endif /* HAVE_CONFIG_H */
 
-#include "common/external.h"
 #include "common/types.h"
 #include "common/error.h"
 #include "common/callback.h"
 #include "common/logger.h"
 #include "common/identity.h"
 #include "common/pull_assert.h"
+#include "common/external.h"
 
 #endif /* LIBPULL_H_ */

--- a/include/common/types.h
+++ b/include/common/types.h
@@ -19,6 +19,13 @@ typedef uint16_t version_t;
 typedef uint16_t platform_t;
 /** Address type to be used across the library */
 typedef uint32_t address_t;
+/** Identifier for the memory objects. It supports at most 255 objects */
+typedef uint8_t memory_id;
+
+typedef enum {
+    true,
+    false
+} bool;
 
 #ifdef __cplusplus
 }

--- a/include/common/types.h
+++ b/include/common/types.h
@@ -20,12 +20,9 @@ typedef uint16_t platform_t;
 /** Address type to be used across the library */
 typedef uint32_t address_t;
 /** Identifier for the memory objects. It supports at most 255 objects */
-typedef uint8_t memory_id;
-
-typedef enum {
-    true,
-    false
-} bool;
+/** This must be a signed integer since negative values are used to define
+ * an invalid object */
+typedef int8_t mem_id_t;
 
 #ifdef __cplusplus
 }

--- a/include/memory/memory.h
+++ b/include/memory/memory.h
@@ -32,6 +32,7 @@ typedef struct mem_object_t mem_object_t;
 typedef struct mem_slot_t {
     mem_id_t id;
     bool bootable;
+    bool loaded;
 } mem_slot_t;
 
 typedef enum {

--- a/include/memory/memory.h
+++ b/include/memory/memory.h
@@ -25,17 +25,17 @@ extern "C" {
 #endif /* __cplusplus */
 
 typedef struct mem_object_ mem_object;
-typedef uint8_t obj_id;
+
+typedef struct memory_object {
+    memory_id id;
+    bool bootable;
+} memory_object;
 
 typedef enum {
     READ_ONLY = 0,
     WRITE_CHUNK = 1, // In this mode the memory will not be completely rewritten.
     WRITE_ALL = 2 // In this mode the memory object will be completely erased before.
 } mem_mode_t;
-
-// TODO This should be refactored to support dinamic memory. This means that this
-// function should receive a mem_object** ctx, in this way it is able to
-// set the pointer value if it allocates the memory
 
 /** 
  * \brief Open a memory object.
@@ -51,7 +51,7 @@ typedef enum {
  * \returns PULL_SUCCESS if the memory was correctly open or the specific
  * erro 
  */
-pull_error memory_open(mem_object* ctx, obj_id id, mem_mode_t mode);
+pull_error memory_open(mem_object* ctx, memory_object id, mem_mode_t mode);
 
 /** 
  * \brief Read bytes from a memory object.
@@ -64,7 +64,7 @@ pull_error memory_open(mem_object* ctx, obj_id id, mem_mode_t mode);
  * \param offset The offset in the memory object from where to start reading.
  * \returns The number of readed bytes or a negative number in case of error.
  */
-int memory_read(mem_object* ctx, void* memory_buffer, uint16_t size, uint32_t offset);
+int memory_read(mem_object* ctx, void* memory_buffer, size_t size, address_t offset);
 
 /** 
  * \brief Write bytes into a memory object.
@@ -77,14 +77,14 @@ int memory_read(mem_object* ctx, void* memory_buffer, uint16_t size, uint32_t of
  * \param offset The offset into the memory object.
  * \returns The number of written bytes or a negative number in case of error.
  */
-int memory_write(mem_object* ctx, const void* memory_buffer, uint16_t size, uint32_t offset);
+int memory_write(mem_object* ctx, const void* memory_buffer, size_t size, address_t offset);
 
 /** 
  * \brief Flush the memory object. (Not mandatory)
  * 
  * This function must not always be implemented. In fact it should be
  * implemented only if the underlying implementation includes some
- * buffer I/O. In that case could be useful to flush the buffer.
+ * buffered I/O. In that case could be useful to flush the buffer.
  * The flush function is not direcly used by the library but may
  * be useful in some situations.
  * \param ctx The memory object containing the buffer to be flushed.

--- a/include/memory/memory.h
+++ b/include/memory/memory.h
@@ -4,7 +4,7 @@
  * The implementation is mandatory as it is used by the library to
  * interact with the memory of the device.
  * 
- * The mem_object type is not defined in the library and must
+ * The mem_object_t type is not defined in the library and must
  * be defined by the memory implementation used to the library.
  * For this reason every time a function that requires to work
  * with memory is called, it must be also passed to it a
@@ -17,19 +17,22 @@
 #ifndef MEMORY_H_
 #define MEMORY_H_
 
-#include <common/libpull.h>
+#include <common/error.h>
+#include <common/types.h>
 #include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
 
-typedef struct mem_object_ mem_object;
+typedef struct mem_object_t mem_object_t;
 
-typedef struct memory_object {
-    memory_id id;
+typedef struct mem_slot_t {
+    mem_id_t id;
     bool bootable;
-} memory_object;
+} mem_slot_t;
 
 typedef enum {
     READ_ONLY = 0,
@@ -51,7 +54,7 @@ typedef enum {
  * \returns PULL_SUCCESS if the memory was correctly open or the specific
  * erro 
  */
-pull_error memory_open(mem_object* ctx, memory_object id, mem_mode_t mode);
+pull_error memory_open(mem_object_t* ctx, mem_id_t id, mem_mode_t mode);
 
 /** 
  * \brief Read bytes from a memory object.
@@ -64,7 +67,7 @@ pull_error memory_open(mem_object* ctx, memory_object id, mem_mode_t mode);
  * \param offset The offset in the memory object from where to start reading.
  * \returns The number of readed bytes or a negative number in case of error.
  */
-int memory_read(mem_object* ctx, void* memory_buffer, size_t size, address_t offset);
+int memory_read(mem_object_t* ctx, void* memory_buffer, size_t size, address_t offset);
 
 /** 
  * \brief Write bytes into a memory object.
@@ -77,7 +80,7 @@ int memory_read(mem_object* ctx, void* memory_buffer, size_t size, address_t off
  * \param offset The offset into the memory object.
  * \returns The number of written bytes or a negative number in case of error.
  */
-int memory_write(mem_object* ctx, const void* memory_buffer, size_t size, address_t offset);
+int memory_write(mem_object_t* ctx, const void* memory_buffer, size_t size, address_t offset);
 
 /** 
  * \brief Flush the memory object. (Not mandatory)
@@ -91,7 +94,7 @@ int memory_write(mem_object* ctx, const void* memory_buffer, size_t size, addres
  * \returns PULL_SUCCESS if the buffer was correcly flushed or the
  * specific error otherwise.
  */
-pull_error memory_flush(mem_object* ctx);
+pull_error memory_flush(mem_object_t* ctx);
 
 /** 
  * \brief Close the memory object.
@@ -100,7 +103,7 @@ pull_error memory_flush(mem_object* ctx);
  * \param ctx The memory object.
  * \returns PULL_SUCCESS on success or a specific error otherwise.
  */
-pull_error memory_close(mem_object* ctx);
+pull_error memory_close(mem_object_t* ctx);
 
 #ifdef __cplusplus
 }

--- a/include/memory/memory_objects.h
+++ b/include/memory/memory_objects.h
@@ -28,20 +28,20 @@ extern "C" {
  *
  * \param[out] id The id of the newest object.
  * \param[out] version The version of the newest object.
- * \param[in] obj_t A temporary mem_object used by the function.
+ * \param[in] obj_t A temporary mem_object_t used by the function.
  * \returns PULL_SUCCESS on success or a specific error otherwise.
  */
-pull_error get_newest_firmware(obj_id *id, version_t *version, mem_object *obj_t);
+pull_error get_newest_firmware(mem_id_t *id, version_t *version, mem_object_t *obj_t);
 
 /**
  * \brief Get the id of the memory object containing the oldest firmware.
  *
  * \param[out] obj The id of the oldest object
  * \param[out] version The version of the oldest object.
- * \param[in] obj_t A temporary mem_object used by the function.
+ * \param[in] obj_t A temporary mem_object_t used by the function.
  * \returns PULL_SUCCESS on success or a specific error otherwise.
  */
-pull_error get_oldest_firmware(obj_id *obj, version_t *version, mem_object *obj_t);
+pull_error get_oldest_firmware(mem_id_t *obj, version_t *version, mem_object_t *obj_t);
 
 /**
  * \brief Copy the firmware s into the firmware d.
@@ -60,7 +60,7 @@ pull_error get_oldest_firmware(obj_id *obj, version_t *version, mem_object *obj_
  *
  * \returns PULL_SUCCESS on success or a specific error otherwise.
  */
-pull_error copy_firmware(mem_object *src, mem_object *dst, uint8_t* buffer, size_t buffer_size);
+pull_error copy_firmware(mem_object_t *src, mem_object_t *dst, uint8_t* buffer, size_t buffer_size);
 
 /**
  * \brief Read the manifest of the memory object.
@@ -72,7 +72,7 @@ pull_error copy_firmware(mem_object *src, mem_object *dst, uint8_t* buffer, size
  * \param[out] mt manifest of the memory object.
  * \returns PULL_SUCCESS on success or a specific error otherwise.
  */
-pull_error read_firmware_manifest(mem_object *obj, manifest_t *mt);
+pull_error read_firmware_manifest(mem_object_t *obj, manifest_t *mt);
 
 /**
  * \brief Write the manifest into the memory object.
@@ -81,7 +81,7 @@ pull_error read_firmware_manifest(mem_object *obj, manifest_t *mt);
  * \param[in] mt The manifest to be written.
  * \returns PULL_SUCCESS on success or a specific error otherwise.
  */
-pull_error write_firmware_manifest(mem_object *obj_t, const manifest_t *mt);
+pull_error write_firmware_manifest(mem_object_t *obj_t, const manifest_t *mt);
 
 /** 
  * \brief  Invalidate a memory object
@@ -91,7 +91,7 @@ pull_error write_firmware_manifest(mem_object *obj_t, const manifest_t *mt);
  * 
  * \returns   
  */
-pull_error invalidate_object(obj_id id, mem_object* obj_t);
+pull_error invalidate_object(mem_id_t id, mem_object_t* obj_t);
 
 
 #ifdef __cplusplus

--- a/include/memory/memory_objects.h
+++ b/include/memory/memory_objects.h
@@ -31,7 +31,8 @@ extern "C" {
  * \param[in] obj_t A temporary mem_object_t used by the function.
  * \returns PULL_SUCCESS on success or a specific error otherwise.
  */
-pull_error get_newest_firmware(mem_id_t *id, version_t *version, mem_object_t *obj_t);
+pull_error get_newest_firmware(mem_id_t *id, version_t *version, mem_object_t *obj_t,
+        bool disable_running, bool prefer_bootable);
 
 /**
  * \brief Get the id of the memory object containing the oldest firmware.
@@ -41,7 +42,8 @@ pull_error get_newest_firmware(mem_id_t *id, version_t *version, mem_object_t *o
  * \param[in] obj_t A temporary mem_object_t used by the function.
  * \returns PULL_SUCCESS on success or a specific error otherwise.
  */
-pull_error get_oldest_firmware(mem_id_t *obj, version_t *version, mem_object_t *obj_t);
+pull_error get_oldest_firmware(mem_id_t *obj, version_t *version, mem_object_t *obj_t,
+        bool disable_running, bool prefer_bootable);
 
 /**
  * \brief Copy the firmware s into the firmware d.

--- a/include/network/receiver.h
+++ b/include/network/receiver.h
@@ -33,7 +33,7 @@ typedef struct {
 typedef struct receiver_ctx_ {
     identity_t identity;
     const char* resource;
-    mem_object* obj;
+    mem_object_t* obj;
     manifest_t mt;
     int manifest_received;
     pull_error err;
@@ -66,7 +66,7 @@ typedef struct receiver_ctx_ {
  * the specific error otherwise.
  */
 pull_error receiver_open(receiver_ctx* ctx, txp_ctx* txp, identity_t identity,
-                        const char* resource, mem_object* obj);
+                        const char* resource, mem_object_t* obj);
 
 /** 
  * \brief Receive and store a chunk of the update into the memory object.

--- a/include/network/subscriber.h
+++ b/include/network/subscriber.h
@@ -50,7 +50,7 @@ void subscriber_cb(pull_error err, const char* data, int len, void* more);
  * 
  * \returns PULL_SUCCESS on success or the specific error otherwise.
  */
-pull_error subscribe(subscriber_ctx* ctx, txp_ctx* txp, const char* resource, mem_object* obj_t);
+pull_error subscribe(subscriber_ctx* ctx, txp_ctx* txp, const char* resource, mem_object_t* obj_t);
 
 /** 
  * \brief Check the presence of an update.

--- a/include/security/verifier.h
+++ b/include/security/verifier.h
@@ -42,7 +42,7 @@ extern "C" {
  * \returns PULL_SUCCESS if verification succeded or the specific error
  * otherwise.
  */
-pull_error verify_object(const mem_object* obj, digest_func f, const uint8_t *x,
+pull_error verify_object(const mem_object_t* obj, digest_func f, const uint8_t *x,
                          const uint8_t *y, ecc_func_t ef,
                          uint8_t* buffer, size_t buffer_len);
 

--- a/src/agents/update.c
+++ b/src/agents/update.c
@@ -47,7 +47,7 @@ agent_t update_agent(update_agent_config* cfg, update_agent_ctx_t* ctx) {
     // (4) Searching slot
     PULL_CONTINUE(STATE_SEARCHING_SLOT);
     uint16_t version;
-    ctx->err = get_oldest_firmware(&ctx->id, &version, &ctx->obj_t);
+    ctx->err = get_oldest_firmware(&ctx->id, &version, &ctx->obj_t, true, true);
     if (ctx->err) {
         log_error(ctx->err, "Error while getting the oldest slot\n");
         PULL_FAILURE(ctx->err);

--- a/src/memory/memory.c
+++ b/src/memory/memory.c
@@ -1,27 +1,27 @@
 #include "memory/memory.h"
 
-pull_error memory_open_impl(mem_object* ctx, obj_id obj, mem_mode_t mode);
-uint16_t memory_read_impl(mem_object* ctx, void* memory_buffer, uint16_t size, uint32_t offset);
-uint16_t memory_write_impl(mem_object* ctx, const void* memory_buffer, uint16_t size, uint32_t offset);
-pull_error memory_flush_impl(mem_object* ctx);
-pull_error memory_close_impl(mem_object* ctx);
+pull_error memory_open_impl(mem_object_t* ctx, mem_id_t id, mem_mode_t mode);
+uint16_t memory_read_impl(mem_object_t* ctx, void* memory_buffer, size_t size, address_t offset);
+uint16_t memory_write_impl(mem_object_t* ctx, const void* memory_buffer, size_t size, address_t offset);
+pull_error memory_flush_impl(mem_object_t* ctx);
+pull_error memory_close_impl(mem_object_t* ctx);
 
-inline pull_error memory_open(mem_object* ctx, obj_id obj, mem_mode_t mode) {
-    return memory_open_impl(ctx, obj, mode);
+inline pull_error memory_open(mem_object_t* ctx, mem_id_t id, mem_mode_t mode) {
+    return memory_open_impl(ctx, id, mode);
 }
 
-inline int memory_read(mem_object* ctx, void* memory_buffer, uint16_t size, uint32_t offset) {
+inline int memory_read(mem_object_t* ctx, void* memory_buffer, size_t size, address_t offset) {
     return memory_read_impl(ctx, memory_buffer, size, offset);
 }
 
-inline int memory_write(mem_object* ctx, const void* memory_buffer, uint16_t size, uint32_t offset) {
+inline int memory_write(mem_object_t* ctx, const void* memory_buffer, size_t size, address_t offset) {
     return memory_write_impl(ctx, memory_buffer, size, offset);
 }
 
-inline pull_error memory_flush(mem_object* ctx) {
+inline pull_error memory_flush(mem_object_t* ctx) {
     return memory_flush_impl(ctx);
 }
 
-inline pull_error memory_close(mem_object* ctx) {
+inline pull_error memory_close(mem_object_t* ctx) {
     return memory_close_impl(ctx);
 }

--- a/src/memory/memory_objects.c
+++ b/src/memory/memory_objects.c
@@ -6,35 +6,37 @@
 #include <stdbool.h>
 
 // if not newest, then is oldest
-pull_error get_ordered_firmware(obj_id* obj, version_t* version, mem_object* obj_t, bool newest) {
+// XXX This function should be improved to check also if the firmware is
+// bootable
+pull_error get_ordered_firmware(mem_id_t* id, version_t* version, mem_object_t* obj_t, bool newest) {
     manifest_t mt;
     pull_error err;
-    obj_id i;
-    for (i=0; memory_objects[i] > 0; i++) {
-        err = memory_open(obj_t, memory_objects[i], READ_ONLY);
+    mem_id_t i;
+    for (i=0; memory_slots[i].id > 0; i++) {
+        err = memory_open(obj_t, memory_slots[i].id, READ_ONLY);
         if (err) {
-            log_error(err, "Failure opening firmware id %d\n", memory_objects[i]);
+            log_error(err, "Failure opening firmware id %d\n", memory_slots[i].id);
             return GET_NEWEST_ERROR;
         }
         err = read_firmware_manifest(obj_t, &mt);
         if (err) {
-            log_error(err, "Failure reading firmware manifest for object %d\n", memory_objects[i]);
+            log_error(err, "Failure reading firmware manifest for object %d\n", memory_slots[i].id);
             return GET_NEWEST_ERROR;
         }
         memory_close(obj_t);
         if (i == 0) {
             *version = mt.vendor.version;
-            *obj = memory_objects[i];
+            *id = memory_slots[i].id;
         } else {
             if (newest == true) {
                 if (mt.vendor.version > *version) {
                     *version = mt.vendor.version;
-                    *obj = memory_objects[i];
+                    *id = memory_slots[i].id; // XXX This needs to be fixed
                 }
             } else {
                 if (mt.vendor.version < *version) {
                 *version= mt.vendor.version;
-                *obj = memory_objects[i];
+                *id = memory_slots[i].id; // This needs to be fixed XXX
                 }
             }
         }
@@ -42,15 +44,15 @@ pull_error get_ordered_firmware(obj_id* obj, version_t* version, mem_object* obj
     return PULL_SUCCESS;
 }
 
-pull_error get_newest_firmware(obj_id* obj, version_t* version, mem_object* obj_t) {
-    return get_ordered_firmware(obj, version, obj_t, true);
+pull_error get_newest_firmware(mem_id_t* id, version_t* version, mem_object_t* obj_t) {
+    return get_ordered_firmware(id, version, obj_t, true);
 }
 
-pull_error get_oldest_firmware(obj_id* obj, version_t* version, mem_object* obj_t) {
-    return get_ordered_firmware(obj, version, obj_t, false);
+pull_error get_oldest_firmware(mem_id_t* id, version_t* version, mem_object_t* obj_t) {
+    return get_ordered_firmware(id, version, obj_t, false);
 }
 
-pull_error copy_firmware(mem_object* src, mem_object* dst, uint8_t* buffer, size_t buffer_size) {
+pull_error copy_firmware(mem_object_t* src, mem_object_t* dst, uint8_t* buffer, size_t buffer_size) {
     manifest_t srcmt;
     int firmware_size = 0;
     if (read_firmware_manifest(src, &srcmt)) {
@@ -79,7 +81,7 @@ pull_error copy_firmware(mem_object* src, mem_object* dst, uint8_t* buffer, size
     return PULL_SUCCESS;
 }
 
-pull_error read_firmware_manifest(mem_object* obj, manifest_t* mt) {
+pull_error read_firmware_manifest(mem_object_t* obj, manifest_t* mt) {
     if (memory_read(obj, (uint8_t*) mt, sizeof(manifest_t), 0) != sizeof(manifest_t)) {
         log_error(MEMORY_READ_ERROR, "Failure reading object\n");
         return READ_MANIFEST_ERROR;
@@ -87,7 +89,7 @@ pull_error read_firmware_manifest(mem_object* obj, manifest_t* mt) {
     return PULL_SUCCESS;
 }
 
-pull_error write_firmware_manifest(mem_object* obj, const manifest_t* mt) {
+pull_error write_firmware_manifest(mem_object_t* obj, const manifest_t* mt) {
     if (memory_write(obj, (uint8_t*) mt, sizeof(manifest_t), 0) != sizeof(manifest_t)) {
         memory_close(obj);
         log_error(MEMORY_WRITE_ERROR, "Failure writing manifest into object\n");
@@ -96,7 +98,7 @@ pull_error write_firmware_manifest(mem_object* obj, const manifest_t* mt) {
     return PULL_SUCCESS;
 }
 
-pull_error invalidate_object(obj_id id, mem_object* obj) {
+pull_error invalidate_object(mem_id_t id, mem_object_t* obj) {
     pull_error err = memory_open(obj, id, WRITE_CHUNK) != PULL_SUCCESS;
     if (err) {
         log_error(err, "Failure opening firmware\n");

--- a/src/network/receiver.c
+++ b/src/network/receiver.c
@@ -73,7 +73,7 @@ static void handler(pull_error txp_err, const char* data, int len, void* more) {
 }
 
 pull_error receiver_open(receiver_ctx* ctx, txp_ctx* txp, identity_t identity,
-        const char* resource, mem_object* obj) {
+        const char* resource, mem_object_t* obj) {
     memset(ctx, 0, sizeof(receiver_ctx));
     ctx->txp = txp;
     ctx->err = PULL_SUCCESS;

--- a/src/network/subscriber.c
+++ b/src/network/subscriber.c
@@ -10,7 +10,7 @@ pull_error subscribe(subscriber_ctx* ctx, txp_ctx* txp, const char* resource, me
     ctx->resource = resource;
     mem_id_t id;
     log_debug("Getting the newest firmware from memory\n");
-    err = get_newest_firmware(&id, &ctx->current_version, obj_t);
+    err = get_newest_firmware(&id, &ctx->current_version, obj_t, false, false);
     if (err) {
         log_error(err, "Impossible to get newest firmware\n");
         return SUBSCRIBE_ERROR;

--- a/src/network/subscriber.c
+++ b/src/network/subscriber.c
@@ -4,11 +4,11 @@
 #include "common/libpull.h"
 #include "network/async.h"
 
-pull_error subscribe(subscriber_ctx* ctx, txp_ctx* txp, const char* resource, mem_object* obj_t) {
+pull_error subscribe(subscriber_ctx* ctx, txp_ctx* txp, const char* resource, mem_object_t* obj_t) {
     pull_error err;
     ctx->txp = txp;
     ctx->resource = resource;
-    obj_id id;
+    mem_id_t id;
     log_debug("Getting the newest firmware from memory\n");
     err = get_newest_firmware(&id, &ctx->current_version, obj_t);
     if (err) {

--- a/src/security/verifier.c
+++ b/src/security/verifier.c
@@ -20,7 +20,7 @@ enum verifier_states {
 };
 
 /* The memory object should be already opened */
-pull_error verify_object(mem_object* obj, digest_func digest, const uint8_t* x, const uint8_t* y,
+pull_error verify_object(mem_object_t* obj, digest_func digest, const uint8_t* x, const uint8_t* y,
         ecc_func_t ef, uint8_t* buffer, size_t buffer_len) {
     if (obj == NULL || x == NULL || y == NULL || buffer == NULL || buffer_len == 0) {
         return INVALID_ARGUMENTS_ERROR;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -21,27 +21,28 @@ MEMORY_SRC = ../src/memory/memory_objects.c
 SECURITY_SRC = ../src/security/verifier.c
 NETWORK_SRC = ../src/network/receiver.c ../src/network/subscriber.c ../src/network/transport_config.c
 AGENTS_SRC = ../src/agents/update.c
+SUPPORT_SRC = support/external_variables.c
 
 NETWORK_IMPL = ../build/posix/transport_libcoap.c ../build/posix/async_libcoap.c
 MEMORY_IMPL = ../src/memory/memory.c ../build/posix/memory_file_posix.c
 MANIFEST_IMPL = ../src/memory/manifest.c ../src/memory/simple_manifest.c
 
 ALL_SRC = $(UNITY_SRC) $(COMMON_SRC) $(MEMORY_SRC) $(SECURITY_SRC) $(MANIFEST_IMPL) $(NETWORK_SRC) $(AGENTS_SRC)
-ALL_SRC += $(NETWORK_IMPL) $(MEMORY_IMPL)
+ALL_SRC += $(NETWORK_IMPL) $(MEMORY_IMPL) $(SUPPORT_SRC)
 
 MOCK_MEMORY = mocks/memory_mock.c ../build/posix/memory_file_posix.c
 MOCK_MANIFEST = mocks/manifest_mock.c ../src/memory/simple_manifest.c
-NO_MOCK_SRC = $(UNITY_SRC) $(COMMON_SRC) $(SECURITY_SRC) $(NETWORK_SRC) $(NETWORK_IMPL) $(MEMORY_SRC)
+NO_MOCK_SRC = $(UNITY_SRC) $(COMMON_SRC) $(SECURITY_SRC) $(NETWORK_SRC) $(NETWORK_IMPL) $(MEMORY_SRC) $(SUPPORT_SRC)
 
 TINYCRYPT_SRC = ../src/security/tinycrypt.c ../ext/tinycrypt/lib/source/ecc_platform_specific.c
 TINYDTLS_SRC = ../src/security/tinydtls.c
 
 memory_tests = test_memory test_memory_objects test_manifest
 agents_tests = test_update
-network_tests = test_receiver test_receiver_memory_invalid test_subscriber test_transport_dtls
+network_tests = test_receiver test_subscriber test_transport_dtls #test_receiver_memory_invalid
 security_tests = test_tinycrypt test_tinydtls
 
-check_PROGRAMS = $(memory_tests)  $(agents_tests) test_receiver test_subscriber test_transport_dtls $(security_tests)
+check_PROGRAMS = $(memory_tests)  $(agents_tests) $(network_tests) $(security_tests)
 TESTS = $(check_PROGRAMS)
 
 # Memory tests

--- a/test/agents/test_update.c
+++ b/test/agents/test_update.c
@@ -27,7 +27,7 @@ void setUp(void) {
     override_memory_object(OBJ_1, "../assets/external_flash_simulator_updated", 0x19000, 0x32000);
     override_memory_object(OBJ_2, "../assets/external_flash_simulator_updated", 0x32000, 0x4B000);
     override_memory_object(OBJ_RUN, "../assets/internal_flash_simulator_updated", 0x7000, 0x20000);
-    mem_object obj_t;
+    mem_object_t obj_t;
     TEST_ASSERT_TRUE(invalidate_object(OBJ_2, &obj_t) == PULL_SUCCESS);
 }
 

--- a/test/memory/test_memory.c
+++ b/test/memory/test_memory.c
@@ -6,7 +6,7 @@
 #include "test_runner.h"
 #include "unity.h"
 
-mem_object object;
+mem_object_t object;
 
 #define FOREACH_TEST(DO) \
     DO(memory_read_sequential, 0) \
@@ -29,7 +29,7 @@ void tearDown(void) {
 }
 
 void test_memory_read_sequential(void) {
-    TEST_ASSERT_MESSAGE(object.fp > 0, "Invadlid File pointer");
+    TEST_ASSERT_MESSAGE(object.fp > 0, "Invalid File pointer");
     int i = 0;
     unsigned char buffer[SIZE*REP];
     TEST_ASSERT_EQUAL_INT(SIZE*REP, memory_read(&object, (unsigned char*) buffer, SIZE*REP, 0x0));
@@ -68,7 +68,7 @@ void test_memory_write_random(void) {
 }
 
 void test_memory_invalid_object(void) {
-    mem_object invalid_object;
+    mem_object_t invalid_object;
     pull_error err = memory_open(&invalid_object, -1, WRITE_ALL);
     TEST_ASSERT_EQUAL(MEMORY_MAPPING_ERROR, err);
     err = memory_open(&invalid_object, 120, WRITE_ALL);

--- a/test/memory/test_memory_objects.c
+++ b/test/memory/test_memory_objects.c
@@ -19,10 +19,10 @@ TEST_RUNNER();
 
 #define BUFFER_SIZE 1024
 
-mem_object obj_run;
-mem_object obj_1;
-mem_object obj_2;
-mem_object obj_t; // This is a temporary object used by the functions
+mem_object_t obj_run;
+mem_object_t obj_1;
+mem_object_t obj_2;
+mem_object_t obj_t; // This is a temporary object used by the functions
 
 void setUp(void) {
     TEST_ASSERT(memory_open(&obj_run, OBJ_RUN, WRITE_ALL) == PULL_SUCCESS);
@@ -37,16 +37,16 @@ void tearDown(void) {
 }
 
 void test_get_newest_firmware(void) {
-    obj_id newest = 0;
+    mem_id_t newest = 0;
     version_t version = 0;
     pull_error err = get_newest_firmware(&newest, &version, &obj_t);
     TEST_ASSERT_TRUE(!err);
     TEST_ASSERT_EQUAL_HEX16(version, 0xbeef);
-    TEST_ASSERT(newest == OBJ_1);
+    TEST_ASSERT(newest == OBJ_RUN);
 }
 
 void test_get_oldest_slot(void) {
-    obj_id oldest;
+    mem_id_t oldest;
     version_t version = 0;
     pull_error err = get_oldest_firmware(&oldest, &version, &obj_t);
     TEST_ASSERT_TRUE(!err);
@@ -64,7 +64,7 @@ void test_read_slot_manifest(void) {
 void test_write_slot_manifest(void) {
     manifest_t mt_old, mt_new;
     version_t version;
-    obj_id newest;
+    mem_id_t newest;
     pull_error err;
     err = read_firmware_manifest(&obj_2, &mt_old);
     TEST_ASSERT_TRUE(!err);

--- a/test/memory/test_memory_objects.c
+++ b/test/memory/test_memory_objects.c
@@ -39,7 +39,7 @@ void tearDown(void) {
 void test_get_newest_firmware(void) {
     mem_id_t newest = 0;
     version_t version = 0;
-    pull_error err = get_newest_firmware(&newest, &version, &obj_t);
+    pull_error err = get_newest_firmware(&newest, &version, &obj_t, false, false);
     TEST_ASSERT_TRUE(!err);
     TEST_ASSERT_EQUAL_HEX16(version, 0xbeef);
     TEST_ASSERT(newest == OBJ_RUN);
@@ -48,7 +48,7 @@ void test_get_newest_firmware(void) {
 void test_get_oldest_slot(void) {
     mem_id_t oldest;
     version_t version = 0;
-    pull_error err = get_oldest_firmware(&oldest, &version, &obj_t);
+    pull_error err = get_oldest_firmware(&oldest, &version, &obj_t, false, false);
     TEST_ASSERT_TRUE(!err);
     TEST_ASSERT_EQUAL_HEX16(0x0, version);
     TEST_ASSERT_EQUAL_INT(OBJ_2, oldest);
@@ -71,7 +71,7 @@ void test_write_slot_manifest(void) {
     mt_new.vendor.version = 0xffff;
     err = write_firmware_manifest(&obj_2, &mt_new);
     TEST_ASSERT_TRUE(!err);
-    get_newest_firmware(&newest, &version, &obj_t);
+    get_newest_firmware(&newest, &version, &obj_t, false, false);
     TEST_ASSERT_EQUAL_INT8(OBJ_2, newest);
     err = write_firmware_manifest(&obj_2, &mt_old);
     TEST_ASSERT_TRUE(!err);

--- a/test/mocks/memory_mock.c
+++ b/test/mocks/memory_mock.c
@@ -2,11 +2,11 @@
 #include "memory/memory.h"
 #include "memory_mock.h"
 
-pull_error memory_open_impl(mem_object* ctx, obj_id obj, mem_mode_t);
-uint16_t memory_read_impl(mem_object* ctx, void* memory_buffer, uint16_t size, uint32_t offset);
-uint16_t memory_write_impl(mem_object* ctx, const void* memory_buffer, uint16_t size, uint32_t offset);
-pull_error memory_flush_impl(mem_object* ctx);
-pull_error memory_close_impl(mem_object* ctx);
+pull_error memory_open_impl(mem_object_t* ctx, mem_id_t obj, mem_mode_t);
+uint16_t memory_read_impl(mem_object_t* ctx, void* memory_buffer, uint16_t size, uint32_t offset);
+uint16_t memory_write_impl(mem_object_t* ctx, const void* memory_buffer, uint16_t size, uint32_t offset);
+pull_error memory_flush_impl(mem_object_t* ctx);
+pull_error memory_close_impl(mem_object_t* ctx);
 
 memory_mock_t memory_mock = {
     .memory_open_impl = memory_open_impl,
@@ -24,38 +24,38 @@ void memory_mock_restore() {
     memory_mock.memory_close_impl = memory_close_impl;
 }
 
-inline pull_error memory_open(mem_object* ctx, obj_id obj, mem_mode_t mode) {
+inline pull_error memory_open(mem_object_t* ctx, mem_id_t obj, mem_mode_t mode) {
     return memory_mock.memory_open_impl(ctx, obj, mode);
 }
 
-inline int memory_read(mem_object* ctx, void* memory_buffer, uint16_t size, uint32_t offset) {
+inline int memory_read(mem_object_t* ctx, void* memory_buffer, size_t size, address_t offset) {
     return memory_mock.memory_read_impl(ctx, memory_buffer, size, offset);
 }
 
-inline int memory_write(mem_object* ctx, const void* memory_buffer, uint16_t size, uint32_t offset) {
+inline int memory_write(mem_object_t* ctx, const void* memory_buffer, size_t size, address_t offset) {
     return memory_mock.memory_write_impl(ctx, memory_buffer, size, offset);
 }
 
-inline pull_error memory_flush(mem_object* ctx) {
+inline pull_error memory_flush(mem_object_t* ctx) {
     return memory_mock.memory_flush_impl(ctx);
 }
 
-inline pull_error memory_close(mem_object* ctx) {
+inline pull_error memory_close(mem_object_t* ctx) {
     return memory_mock.memory_close_impl(ctx);
 }
 
-pull_error memory_open_invalid(mem_object* ctx, obj_id obj, mem_mode_t mode) {
+pull_error memory_open_invalid(mem_object_t* ctx, mem_id_t obj, mem_mode_t mode) {
     return GENERIC_ERROR;
 }
-uint16_t memory_read_invalid(mem_object* ctx, void* memory_buffer, uint16_t size, uint32_t offset) {
+uint16_t memory_read_invalid(mem_object_t* ctx, void* memory_buffer, uint16_t size, uint32_t offset) {
     return 0;
 }
-uint16_t memory_write_invalid(mem_object* ctx, const void* memory_buffer, uint16_t size, uint32_t offset) {
+uint16_t memory_write_invalid(mem_object_t* ctx, const void* memory_buffer, uint16_t size, uint32_t offset) {
     return 0;
 }
-pull_error memory_flush_invalid(mem_object* ctx) {
+pull_error memory_flush_invalid(mem_object_t* ctx) {
     return GENERIC_ERROR;
 }
-pull_error memory_close_invalid(mem_object* ctx) {
+pull_error memory_close_invalid(mem_object_t* ctx) {
     return GENERIC_ERROR;
 }

--- a/test/mocks/memory_mock.h
+++ b/test/mocks/memory_mock.h
@@ -4,21 +4,21 @@
 #include "memory/memory.h"
 
 typedef struct {
-    pull_error (*memory_open_impl) (mem_object*, obj_id, mem_mode_t);
-    uint16_t (*memory_read_impl)(mem_object*, void*, uint16_t, uint32_t);
-    uint16_t (*memory_write_impl)(mem_object*, const void*, uint16_t, uint32_t);
-    pull_error (*memory_flush_impl)(mem_object*);
-    pull_error (*memory_close_impl)(mem_object*);
+    pull_error (*memory_open_impl) (mem_object_t*, mem_id_t, mem_mode_t);
+    uint16_t (*memory_read_impl)(mem_object_t*, void*, uint16_t, uint32_t);
+    uint16_t (*memory_write_impl)(mem_object_t*, const void*, uint16_t, uint32_t);
+    pull_error (*memory_flush_impl)(mem_object_t*);
+    pull_error (*memory_close_impl)(mem_object_t*);
 } memory_mock_t;
 
 extern memory_mock_t memory_mock;
 
 void memory_mock_restore();
 
-pull_error memory_open_invalid(mem_object* ctx, obj_id obj, mem_mode_t);
-uint16_t memory_read_invalid(mem_object* ctx, void* memory_buffer, uint16_t size, uint32_t offset);
-uint16_t memory_write_invalid(mem_object* ctx, const void* memory_buffer, uint16_t size, uint32_t offset);
-pull_error memory_flush_invalid(mem_object* ctx);
-pull_error memory_close_invalid(mem_object* ctx);
+pull_error memory_open_invalid(mem_object_t* ctx, mem_id_t obj, mem_mode_t);
+uint16_t memory_read_invalid(mem_object_t* ctx, void* memory_buffer, uint16_t size, uint32_t offset);
+uint16_t memory_write_invalid(mem_object_t* ctx, const void* memory_buffer, uint16_t size, uint32_t offset);
+pull_error memory_flush_invalid(mem_object_t* ctx);
+pull_error memory_close_invalid(mem_object_t* ctx);
 
 #endif /* MEMORY_MOCK_H_ */

--- a/test/network/test_receiver.c
+++ b/test/network/test_receiver.c
@@ -22,7 +22,7 @@ TEST_RUNNER();
 
 #define PROV_SERVER "localhost"
 
-mem_object obj;
+mem_object_t obj;
 
 void setUp(void) {
     TEST_ASSERT_TRUE(memory_open(&obj, OBJ_2, WRITE_ALL) == PULL_SUCCESS);

--- a/test/network/test_subscriber.c
+++ b/test/network/test_subscriber.c
@@ -36,7 +36,7 @@ void test_update_polling(void) {
     subscriber_ctx ctx;
     txp_ctx txp;
     txp_init(&txp, PROV_SERVER, 0, PULL_UDP, NULL);
-    mem_object obj_t;
+    mem_object_t obj_t;
     pull_error err = subscribe(&ctx, &txp, "version", &obj_t);
     TEST_ASSERT_TRUE(!err);
     err = check_updates(&ctx, check_update_cb);

--- a/test/security/test_tinycrypt.c
+++ b/test/security/test_tinycrypt.c
@@ -16,7 +16,7 @@
 
 digest_func df;
 ecc_func_t ef;
-mem_object obj_1;
+mem_object_t obj_1;
 
 #include "test_verifier.h"
 

--- a/test/security/test_tinydtls.c
+++ b/test/security/test_tinydtls.c
@@ -16,7 +16,7 @@
 
 digest_func df;
 ecc_func_t ef;
-mem_object obj_1;
+mem_object_t obj_1;
 
 #include "test_verifier.h"
 

--- a/test/support/external_variables.c
+++ b/test/support/external_variables.c
@@ -1,0 +1,27 @@
+/* This file is used to define the external variables
+ * that must be defined to compile the library. In this case
+ * will be used for the tests, but in a running version will
+ * be obviously different
+ */
+
+/*** Memory configuration for tests */
+const mem_slot_t memory_slots[] = {
+    {
+        .id = OBJ_RUN,
+        .bootable = true,
+        .loaded = true
+    },
+    {
+        .id = OBJ_1,
+        .bootable = false,
+        .loaded = false
+    },
+    {
+        .id = OBJ_2,
+        .bootable = false,
+        .loaded = false
+    },
+    {OBJ_END}
+};
+
+const version_t running_version = 0x0001;

--- a/test/support/external_variables.c
+++ b/test/support/external_variables.c
@@ -4,24 +4,7 @@
  * be obviously different
  */
 
-/*** Memory configuration for tests */
-const mem_slot_t memory_slots[] = {
-    {
-        .id = OBJ_RUN,
-        .bootable = true,
-        .loaded = true
-    },
-    {
-        .id = OBJ_1,
-        .bootable = false,
-        .loaded = false
-    },
-    {
-        .id = OBJ_2,
-        .bootable = false,
-        .loaded = false
-    },
-    {OBJ_END}
-};
+#include <common/libpull.h>
+#include <memory/memory.h>
 
 const version_t running_version = 0x0001;


### PR DESCRIPTION
In this PR I want to target #15 and simplify the way the update agents works. In fact, they actually consider one slot as the running slot, and this concepts is not good considering that may be more than one bootable slot. A good description of the problem is represented in #15.

To complete this PR I need to:

- [x] refactor memory module;
- [x] refactor memory_objects;
- [x] refactor all the modules using the new API;
- [x] fix tests;

This closes #15.