### PR TITLE
Enforce freestanding core

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 AUTOMAKE_OPTIONS = subdir-objects
 SUBDIRS = test
 
-AM_CFLAGS = -Wall -I. -Iinclude -Iext/tinycrypt/lib/include -Iext/tinydtls -DHAVE_CONFIG_H -ffreestanding -pedantic-errors
+AM_CFLAGS = -Wall -I. -Iinclude -Iext/tinycrypt/lib/include -Iext/tinydtls -DHAVE_CONFIG_H -ffreestanding -pedantic-errors -std=c99
 
 noinst_LIBRARIES = libpull.a
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 AUTOMAKE_OPTIONS = subdir-objects
 SUBDIRS = test
 
-AM_CFLAGS = -Wall -I. -Iinclude -Iext/tinycrypt/lib/include -Iext/tinydtls -DHAVE_CONFIG_H -ffreestanding
+AM_CFLAGS = -Wall -I. -Iinclude -Iext/tinycrypt/lib/include -Iext/tinydtls -DHAVE_CONFIG_H -ffreestanding -pedantic-errors
 
 noinst_LIBRARIES = libpull.a
 
@@ -10,7 +10,7 @@ libpull_a_SOURCES += src/core/memory/manifest.c src/core/memory/memory_objects.c
 libpull_a_SOURCES += src/core/memory/memory_impl.c src/core/memory/memory_flash.c
 libpull_a_SOURCES += src/core/network/receiver.c src/core/network/subscriber.c src/core/network/connection_config.c src/core/network/writer.c
 libpull_a_SOURCES += src/core/security/verifier.c src/core/security/tinycrypt.c src/core/security/tinydtls.c src/core/security/cryptoauthlib.c
-libpull_a_SOURCES += src/core/pipeline/lzss.c src/core/pipeline/bspatch.c
+libpull_a_SOURCES += src/core/pipeline/lzss.c src/core/pipeline/bspatch.c src/core/pipeline/buffer.c
 
 pkginclude_HEADERS = include/
 # TODO Finish including all the headers

--- a/include/libpull/common/logger.h
+++ b/include/libpull/common/logger.h
@@ -45,16 +45,16 @@ extern uint8_t verbosity_level;
 
 #if LOGGER_VERBOSITY > 0
 
-#define log_impl(verbosity, args...) \
+#define log_impl(verbosity, ...) \
     if (verbosity <= verbosity_level) { \
-        log_output(args);}
+        log_output(__VA_ARGS__);}
 
 #if LOGGER_VERBOSITY >= VERBOSITY_DEBUG
-    #define log_err(error, args...) \
+    #define log_err(error, ...) \
         log_output("%s:", err_as_str(error)); \
-        log_output(args);
+        log_output(__VA_ARGS__);
 #else
-    #define log_err(error, args...) \
+    #define log_err(error, ...) \
         log_output("%s\n", err_as_str(error));
 #endif
 
@@ -63,16 +63,16 @@ extern uint8_t verbosity_level;
 #define log_err(...)
 #endif /* LOGGER_VERBOSITY */
 
-#define log_debug(args...) log_impl(VERBOSITY_DEBUG, args)
-#define log_info(args...) log_impl(VERBOSITY_INFO, args)
+#define log_debug(...) log_impl(VERBOSITY_DEBUG, __VA_ARGS__)
+#define log_info(...) log_impl(VERBOSITY_INFO, __VA_ARGS__)
 /**
  * \brief This function takes as first parameter an error and
  * then an arbitrary number of arguments that will be printed.
  * The first arguemnt will be used to print the literal value
  * of the error.
  */
-#define log_error(err, args...) log_err(err, args)
-#define log_warn(args...) log_impl(VERBOSITY_WARN, args)
+#define log_error(err, ...) log_err(err, __VA_ARGS__)
+#define log_warn(...) log_impl(VERBOSITY_WARN, __VA_ARGS__)
 
 #ifdef __cplusplus
 }

--- a/include/libpull/pipeline/pipeline.h
+++ b/include/libpull/pipeline/pipeline.h
@@ -31,7 +31,7 @@ typedef struct pipeline_func_t {
 /** 
  * \brief  This structure defines the context for each stage of the pipeline;
  */
-typedef struct pipeline_ctx_t {
+struct pipeline_ctx_t {
     int state;                  //< Internal state of the pipeline stage
                                 //< (since many stages uses Duff's device).
     void* more;
@@ -43,7 +43,7 @@ typedef struct pipeline_ctx_t {
                                 //< stage of the pipeline
     pipeline_ctx_t* next_ctx;   //< Pointer to the context to be passed to the
                                 //< next stage of the pipeline
-} pipeline_ctx_t;
+};
 
 #ifdef __cplusplus
 }

--- a/include/libpull/security/ecc.h
+++ b/include/libpull/security/ecc.h
@@ -34,7 +34,7 @@ typedef struct {
         .verify = impl##_ecc_verify, \
         .sign = impl##_ecc_sign, \
         .curve_size = size \
-    };
+    }
 
 #ifdef WITH_TINYDTLS
     ECC_VERIFY(tinydtls_secp256r1);

--- a/src/core/common/error.c
+++ b/src/core/common/error.c
@@ -1,7 +1,7 @@
 #include <libpull/common.h>
 
 #if LOGGER_VERBOSITY >= 2
-static const char* error_str[] = {
+const char* error_str[] = {
     "PULL_SUCCESS",
     FOREACH_ERROR(GENERATE_STRING)
 }; 


### PR DESCRIPTION
As discussed in issue #46, we want to have a freestanding library core easily portable to other hosted implementations.

This PR closes issue #46.